### PR TITLE
Fix segfault when using CRTA 

### DIFF
--- a/src/bte/scattering_matrix.cpp
+++ b/src/bte/scattering_matrix.cpp
@@ -501,11 +501,13 @@ VectorBTE ScatteringMatrix::getSingleModeTimes(const VectorBTE& anyInternalDiago
 
   // just using the shape of internalDiagonal, will be overwritten
   VectorBTE times(statisticsSweep, outerBandStructure, 1);
-  times = anyInternalDiagonal.reciprocal();
 
   if (constantRTA) {
     times.setConst(context.getConstantRelaxationTime() / twoPi);
   } else {
+
+    times = anyInternalDiagonal.reciprocal();
+
     if (!isMatrixOmega) { // A_nu,nu = N(1+-N) / tau  -- for phonon case
       auto particle = outerBandStructure.getParticle();
       #pragma omp parallel for
@@ -1082,10 +1084,10 @@ void ScatteringMatrix::addRateToMatrix(const Context &context, double linewidthR
   auto [iBte1Shift, iBte2Shift] = shiftToCoupledIndices(iBte1, iBte2, p1, p2);
 
   if (matrixCase == fullMatrix) { // case of matrix construction
-    if (context.getUseSymmetries()) { // indices are never shifted in the sym case, currently 
+    if (context.getUseSymmetries()) { // indices are never shifted in the sym case, currently
       BteIndex iBte1Idx(iBte1);
       BteIndex iBte2Idx(iBte2);
-      
+
       linewidth->operator()(iCalc, 0, iBte1) += linewidthRate;
 
       for (int i : {0, 1, 2}) {
@@ -1455,7 +1457,7 @@ void ScatteringMatrix::enforceDetailedBalance() {
   newLinewidths.setZero();
 
   double Nk = 1;
-  double Nq = 1; 
+  double Nq = 1;
   if(isCoupled) {
     Nk = double(context.getKMesh().prod());
     Nq = double(context.getQMesh().prod());
@@ -1471,7 +1473,7 @@ void ScatteringMatrix::enforceDetailedBalance() {
   // NOTE: if later we want to use symmetries here,
   // these would actually be iBTE instead of iState, and we would convert
   // sum over the v' states owned by this process
-  // TODO may want to add OMP here as well as MPI 
+  // TODO may want to add OMP here as well as MPI
   for (auto [ibte1, ibte2] : getAllLocalStates()) {
 
     loopPrint.update();
@@ -1524,7 +1526,7 @@ void ScatteringMatrix::enforceDetailedBalance() {
     if((initialParticle.isPhonon() && initialEn < 1e-9)) continue;
     if((finalParticle.isPhonon() && finalEn < 1e-9)) continue;
 
-    // if this is a matrix which is not symmetrized, we don't need these. 
+    // if this is a matrix which is not symmetrized, we don't need these.
     // calculate f(1-f) or n(n+1)
     // do not shift E by mu because we use this below in the getPop function which assumes it's unshifted
     double initialFFm1 = (!isMatrixOmega) ? 1 : initialParticle.getPopPopPm1(initialEn, kBT, initialChemicalPotential);
@@ -1605,7 +1607,7 @@ void ScatteringMatrix::enforceDetailedBalance() {
       }
     }
   }
-/* 
+/*
   if(mpi->mpiHead()) {
 
     std::cout << "compare first 50 el states, new vs. old " << std::setw(2) << std::scientific << std::setprecision(2) << std::endl;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -134,7 +134,7 @@ void IO::goodbye(Context &context) {
   // wigner transport
   if(context.getAppName() == "phononTransport"
         || context.getAppName() == "electronWannierTransport") {
-          
+
     std::cout << "  For the Wigner transport equations:" << std::endl;
     std::cout << "\tM. Simoncelli, N. Marzari, and F. Mauri.\n" <<
     //    "\tUnified theory of thermal transport in crystals and glasses.\n" <<
@@ -143,7 +143,7 @@ void IO::goodbye(Context &context) {
     //    "\tInterband tunneling effects on materials transport properties using the first principles Wigner distribution.\n" <<
         "\tMaterials Today Physics 19, 100412 (2021).\n" << std::endl;
   }
-  // EPA 
+  // EPA
   // TODO add the fourier interpolation -- Boltztrap??
   if(context.getElPhInterpolation() == "epa" || context.getAppName() == "transportEpa") {
     std::cout << "  For the use of the EPA method:" << std::endl;
@@ -156,7 +156,7 @@ void IO::goodbye(Context &context) {
   if(context.getAppName() == "electronWannierBands" ||
         context.getAppName() == "electronWannierDos" ||
         context.getAppName() == "electronLifetimes" ||
-        context.getAppName() == "electronWannierTransport" || 
+        context.getAppName() == "electronWannierTransport" ||
         context.getAppName() == "coupledTransport") {
     std::cout << "  For the use of Wannier functions and interpolation:" << std::endl;
     std::cout << "\tN. Marzari, A.A. Mostofi, J.R. Yates, I. Souza, and D. Vanderbilt.\n" <<
@@ -185,8 +185,8 @@ void IO::goodbye(Context &context) {
              "\tPhysical Review Letters 106, 045901 (2011)\n" << std::endl;
   }
   // scattering matrix/bte symmetries
-  if (context.getScatteringMatrixInMemory() && context.getUseSymmetries() && 
-       (context.getAppName() == "electronWannierTransport" || 
+  if (context.getScatteringMatrixInMemory() && context.getUseSymmetries() &&
+       (context.getAppName() == "electronWannierTransport" ||
         context.getAppName() == "phononTransport")) {
 
     std::cout << "  For the use of symmetries in the scattering matrix:" << std::endl;
@@ -206,7 +206,7 @@ LoopPrint::LoopPrint(const std::string &task_, const std::string &step_,
   step = step_;
   numSteps = numSteps_;
 
-  int numRep = 10; // number of intermediate reports
+  size_t numRep = 10; // number of intermediate reports
   if (numSteps < numRep) {
     reportEvery = 1;
   } else {


### PR DESCRIPTION
Fix a segfault which could occur when reciprocal was called on an unallocated linewidth object during getSingleModeTimes in the CRTA case. This simply required moving a line into a block which first checked if CRTA is used.