### PR TITLE
relaxonVelocities branch: correcting lifetimes & viscosity iiii contributions written to hdf5

### DIFF
--- a/src/observable/relaxons.cpp
+++ b/src/observable/relaxons.cpp
@@ -214,7 +214,7 @@ void outputRelaxonsToHDF5(ParallelMatrix<double>& eigenvectors,
     int numBands = bandStructure->getFullNumBands();
     Particle particle = bandStructure->getParticle();
     // convertion for time units
-    double energyToTime = particle.isPhonon() ? energyRyToFs * 1e-3 : energyRyToFs;
+    double energyToTime = particle.isPhonon() ? energyRyToFs * 1e-3 / twoPi : energyRyToFs;
 
     // cannot use vector<vector> as this is not contiguous
     Eigen::Tensor<double,3> relaxon(numPoints, numBands, numRelaxonsToOutput);
@@ -443,7 +443,7 @@ void outputRelaxonContributionsToHDF5(const Eigen::VectorXd& eigenvalues,
                                       const Particle& particle,
                                       const int numRelaxons) {
 
-  double energyToTime = particle.isPhonon() ? energyRyToFs * 1e-3 : energyRyToFs;
+  double energyToTime = particle.isPhonon() ? energyRyToFs * 1e-3 / twoPi : energyRyToFs;
 
   Eigen::VectorXd tau = energyToTime * eigenvalues.array().inverse();
   Eigen::MatrixXd Vphi_x(numRelaxons, 3);  Vphi_x.setZero();

--- a/src/observable/transport_coefficients.cpp
+++ b/src/observable/transport_coefficients.cpp
@@ -190,6 +190,11 @@ void TransportCoefficients::calcFromRelaxons(const Eigen::VectorXd &eigenvalues,
     // NOTE: remove energy and charge eigenvectors
     if (gamma == alpha0 || gamma == alpha_e)  continue;
 
+    // viscosity iiii contribution  --------------------------
+    double xxxx = sqrt(A(0) * A(0)) * Vphi(gamma, 0, 0) * Vphi(gamma, 0, 0) * tau;
+    double yyyy =  sqrt(A(1) * A(1)) * Vphi(gamma, 1, 1) * Vphi(gamma, 1, 1) * tau;
+    iiiiContrib[gamma] += (xxxx + yyyy) / 2.;
+
     for (int i = 0; i < dimensionality; i++) {
       for (int j = 0; j < dimensionality; j++) {
 
@@ -198,10 +203,6 @@ void TransportCoefficients::calcFromRelaxons(const Eigen::VectorXd &eigenvalues,
         kappaContrib(gamma,i,j) += specificHeat(0) / kBoltzmannRy * V0(gamma,i) * V0(gamma,j) * tau;
 
         // viscosities ----------------------------------------------------
-        double xxxx = sqrt(A(0) * A(0)) * Vphi(gamma, 0, 0) * Vphi(gamma, 0, 0) * tau;
-        double yyyy =  sqrt(A(1) * A(1)) * Vphi(gamma, 1, 1) * Vphi(gamma, 1, 1) * tau;
-        iiiiContrib[gamma] += (xxxx + yyyy) / 2.;
-
         for(auto k : {0, 1, 2}) {
           for(auto l : {0, 1, 2}) {
             viscosity(0,i,j,k,l) += sqrt(A(i) * A(k)) * Vphi(gamma,i,j) * Vphi(gamma,l,k) * tau;


### PR DESCRIPTION
Two small changes:

- i) apply 2pi division to relaxon lifetimes written to hdf5 files during output (src/observable/relaxons.cpp)
- ii) move iiiiContrib out of nested for loops to prevent duplicated relaxon contributions to each viscosity component (src/observable/transport_coefficients.cpp)

-> means that kappa or viscosity contributions reconstructed using relaxon transport properties (written during output to hdf5) match within numerical tolerance the kappa / viscosity contributions (and totals) written to json.

Note that in i), the division by 2pi is only performed if isPhonon() evaluates to true. Right now I only have phonon BTE inputs/outputs at hand, so I did not check in my calculations if the same issue exists for the electronBTE. Probably the twoPi division should be applied in both cases.